### PR TITLE
fix(api): improve Renpho measurement sync handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that pr
 - **Body Composition Data**: Weight, BMI, body fat %, muscle mass, water %, bone mass, visceral fat, metabolic age, BMR, and more
 - **Weight Trends**: Track changes over customizable time periods (7-365 days)
 - **Health Classifications**: Automatic BMI, body fat, and visceral fat category assessments
-- **Measurement History**: Access historical data with filtering options
+- **Measurement History**: Access historical measurements with date filtering
+- **Multi-table discovery**: Scans all linked Renpho scale tables instead of assuming the first discovered scale-user ID is always correct
+- **Sync diagnostics**: Inspect linked scale-user IDs, hidden measurements, and likely delayed Wi-Fi sync situations
 - **Secure**: Credentials stored as environment variables, never logged
 
 ## Requirements
@@ -76,11 +78,14 @@ Add to `claude_desktop_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `get_latest_measurement` | Most recent body composition reading |
+| `get_latest_measurement` | Most recent body composition reading selected for the current user |
 | `get_body_composition` | Detailed composition with health classifications |
 | `get_weight_trend` | Weight change analysis over N days |
 | `get_measurements` | Historical measurements with date filtering |
 | `get_current_user` | User profile information |
+| `get_scale_users` | Linked scale-user IDs and Renpho table mappings |
+| `get_sync_diagnostics` | Debug hidden/delayed measurements across linked scale users |
+| `refresh_data` | Clear caches and force a fresh Renpho session |
 | `health_check` | Verify API connection status |
 
 ## Example Usage
@@ -91,13 +96,22 @@ Once configured, ask Claude:
 - "Show my weight trend over the last 90 days"
 - "How has my body fat percentage changed this year?"
 - "Get my last 10 measurements"
+- "Show my Renpho scale user IDs"
+- "Run sync diagnostics for the last 7 days"
+- "Refresh Renpho data and re-check my latest measurement"
 
 ## Technical Notes
 
 - Uses the Renpho Health API (`cloud.renpho.com`), not the legacy API
 - Implements AES-128-ECB encryption for API communication
 - Handles JavaScript BigInt precision for large user IDs
+- Scans all discovered Renpho scale tables and scale-user IDs before selecting measurements for the current user
+- Includes a sync diagnostics tool to surface measurements associated with linked scale users but not currently selected for the logged-in user
 - Caches authentication tokens (50 min) and measurements (5 min) to reduce API calls
+
+## Known Wi-Fi Scale Sync Caveat
+
+Some Wi-Fi scales appear to upload measurements that are not immediately bound to the expected Renpho user until the mobile app performs additional sync logic. This server now helps debug that state with `get_scale_users`, `get_sync_diagnostics`, and `refresh_data`, but the exact server-side binding call used by the app is still being investigated.
 
 ## Privacy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renpho-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for Renpho smart scale body composition data",
   "type": "module",
   "main": "dist/index.js",
@@ -11,6 +11,7 @@
     "build": "tsc && chmod +x dist/index.js",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "test": "tsx --test test/**/*.test.ts",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
     "inspector": "npx @modelcontextprotocol/inspector dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ import {
   formatMeasurement,
   formatBodyComposition,
   formatWeightTrend,
-  formatMeasurementList
+  formatMeasurementList,
+  formatScaleUsers,
+  formatSyncDiagnostics
 } from './utils/formatting.js';
 import { createLogger, format, transports } from 'winston';
 
@@ -34,7 +36,7 @@ const renphoApi = new RenphoApiService(config.email, config.password);
 
 const server = new McpServer({
   name: 'renpho-mcp-server',
-  version: '1.0.0'
+  version: '1.1.0'
 });
 
 server.tool(
@@ -51,6 +53,25 @@ server.tool(
       };
     } catch (error) {
       logger.error('Failed to get current user', { error: (error as Error).message });
+      throw error;
+    }
+  }
+);
+
+server.tool(
+  'get_scale_users',
+  'Get linked Renpho scale-user IDs and table mappings discovered from the account',
+  async () => {
+    try {
+      const scaleUsers = await renphoApi.getScaleUsers();
+      return {
+        content: [{
+          type: 'text' as const,
+          text: formatScaleUsers(scaleUsers)
+        }]
+      };
+    } catch (error) {
+      logger.error('Failed to get scale users', { error: (error as Error).message });
       throw error;
     }
   }
@@ -163,6 +184,47 @@ server.tool(
 );
 
 server.tool(
+  'get_sync_diagnostics',
+  {
+    days: z.number().min(1).max(30).default(7).describe('How many recent days to inspect for hidden or delayed measurements (default: 7)')
+  },
+  async ({ days }: { days: number }) => {
+    try {
+      const diagnostics = await renphoApi.getSyncDiagnostics(days);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: formatSyncDiagnostics(diagnostics)
+        }]
+      };
+    } catch (error) {
+      logger.error('Failed to get sync diagnostics', { error: (error as Error).message, days });
+      throw error;
+    }
+  }
+);
+
+server.tool(
+  'refresh_data',
+  'Clear Renpho auth/measurement caches and re-fetch account state. Useful after taking a new measurement or after the mobile app syncs.',
+  async () => {
+    try {
+      renphoApi.invalidateCaches();
+      const user = await renphoApi.getCurrentUser();
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Renpho cache cleared and session refreshed for ${user.email}.`
+        }]
+      };
+    } catch (error) {
+      logger.error('Failed to refresh data', { error: (error as Error).message });
+      throw error;
+    }
+  }
+);
+
+server.tool(
   'health_check',
   'Check the health status of the Renpho MCP server and API connection',
   async () => {
@@ -171,7 +233,7 @@ server.tool(
       return {
         content: [{
           type: 'text' as const,
-          text: `Renpho MCP Server Health Check\n\nStatus: Healthy\nTimestamp: ${new Date().toISOString()}\nAPI Connection: OK\nUser: ${user.email}\nVersion: 1.0.0`
+          text: `Renpho MCP Server Health Check\n\nStatus: Healthy\nTimestamp: ${new Date().toISOString()}\nAPI Connection: OK\nUser: ${user.email}\nVersion: 1.1.0`
         }]
       };
     } catch (error) {

--- a/src/services/renpho-api.ts
+++ b/src/services/renpho-api.ts
@@ -197,9 +197,9 @@ export class RenphoApiService {
       return cached;
     }
 
-    // API returns oldest first, so fetch all records when filtering by date
+    // API returns oldest first, so fetch more records when filtering by date
     // to ensure we get recent measurements, then apply limit after filtering
-    const fetchSize = lastAt ? 2000 : limit;
+    const fetchSize = lastAt ? Math.max(limit, 500) : limit;
 
     const measurementRequest = {
       pageNum: 1,
@@ -208,22 +208,36 @@ export class RenphoApiService {
       tableName: session.tableName
     };
 
-    const response = await fetch(`${API_BASE}/RenphoHealth/scale/queryAllMeasureDataList`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'token': session.token,
-        'userId': session.userId,
-        'appVersion': '7.0.0',
-        'platform': 'android'
-      },
-      body: JSON.stringify({ encryptData: this.encryptAES(JSON.stringify(measurementRequest)) })
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${API_BASE}/RenphoHealth/scale/queryAllMeasureDataList`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'token': session.token,
+          'userId': session.userId,
+          'appVersion': '7.0.0',
+          'platform': 'android'
+        },
+        body: JSON.stringify({ encryptData: this.encryptAES(JSON.stringify(measurementRequest)) })
+      });
+    } catch (networkError) {
+      throw new Error(`Network error fetching measurements: ${(networkError as Error).message}`);
+    }
 
-    const responseJson = await response.json() as { code: number; msg: string; data: string };
+    let responseJson: { code: number; msg?: string; data?: string };
+    try {
+      responseJson = await response.json() as { code: number; msg?: string; data?: string };
+    } catch (parseError) {
+      throw new Error(`Failed to parse API response: ${(parseError as Error).message}, status: ${response.status}`);
+    }
 
     if (responseJson.code !== 101) {
-      throw new Error(`Failed to get measurements: ${responseJson.msg}`);
+      throw new Error(`Failed to get measurements: code=${responseJson.code}, msg=${responseJson.msg}, full=${JSON.stringify(responseJson)}`);
+    }
+
+    if (!responseJson.data) {
+      throw new Error('Failed to get measurements: No data in response');
     }
 
     const rawMeasurements = JSON.parse(this.decryptAES(responseJson.data)) as Array<Record<string, any>>;

--- a/src/services/renpho-api.ts
+++ b/src/services/renpho-api.ts
@@ -5,27 +5,47 @@ import {
   RenphoMeasurement,
   RenphoScaleUser,
   RenphoWeightTrend,
-  RenphoBodyComposition
+  RenphoBodyComposition,
+  RenphoScaleTable,
+  RenphoSyncDiagnostics
 } from '../types/renpho.js';
 
 const API_BASE = 'https://cloud.renpho.com';
 const ENCRYPTION_SECRET = 'ed*wijdi$h6fe3ew';
+const DEFAULT_PAGE_SIZE = 200;
+const MAX_MEASUREMENT_SCAN = 1000;
 
 interface CachedSession {
   token: string;
   userId: string;
-  scaleUserId: string;
-  tableName: string;
+  scaleUserIds: string[];
+  scaleTables: RenphoScaleTable[];
   user: RenphoUser;
   expires_at: number;
 }
 
 interface DeviceInfo {
   scale: Array<{
-    userIds: string[];
+    userIds: Array<string | number>;
     count: number;
     tableName: string;
   }>;
+}
+
+interface FamilyMemberResponse {
+  id?: string | number;
+  email?: string;
+  accountName?: string;
+  birthday?: string;
+  gender?: number;
+  height?: number;
+  heightUnit?: number;
+  weightUnit?: number;
+  weightGoal?: number;
+  locale?: string;
+  areaCode?: string;
+  firstName?: string;
+  lastName?: string;
 }
 
 export class RenphoApiService {
@@ -69,11 +89,74 @@ export class RenphoApiService {
     return match ? match[1] : null;
   }
 
-  // Extract userIds array as string array to avoid precision loss
-  private extractUserIdsAsStrings(json: string): string[] {
-    const match = json.match(/"userIds":\[(\d+(?:,\d+)*)\]/);
-    if (!match) return [];
-    return match[1].split(',');
+  // Extract all userIds arrays as string arrays to avoid precision loss
+  private extractUserIdGroupsAsStrings(json: string): string[][] {
+    const matches = json.matchAll(/"userIds":\[(\d+(?:,\d+)*)\]/g);
+    return Array.from(matches, match => match[1].split(','));
+  }
+
+  private unique<T>(items: T[]): T[] {
+    return [...new Set(items)];
+  }
+
+  invalidateCaches(): void {
+    this.sessionCache = null;
+    this.measurementCache.clear();
+  }
+
+  private async postEncryptedRaw(
+    path: string,
+    session: CachedSession,
+    requestBody: Record<string, unknown> | null,
+    emptyBody: boolean = false
+  ): Promise<string> {
+    let response: Response;
+    try {
+      response = await fetch(`${API_BASE}/${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'token': session.token,
+          'userId': session.userId,
+          'appVersion': '7.0.0',
+          'platform': 'android'
+        },
+        body: JSON.stringify({
+          encryptData: emptyBody
+            ? this.encryptEmptyBytes()
+            : this.encryptAES(JSON.stringify(requestBody ?? {}))
+        })
+      });
+    } catch (networkError) {
+      throw new Error(`Network error calling ${path}: ${(networkError as Error).message}`);
+    }
+
+    let responseJson: { code: number; msg?: string; data?: string };
+    try {
+      responseJson = await response.json() as { code: number; msg?: string; data?: string };
+    } catch (parseError) {
+      throw new Error(`Failed to parse API response from ${path}: ${(parseError as Error).message}, status: ${response.status}`);
+    }
+
+    if (responseJson.code !== 101) {
+      throw new Error(`API call failed for ${path}: code=${responseJson.code}, msg=${responseJson.msg}, full=${JSON.stringify(responseJson)}`);
+    }
+
+    if (!responseJson.data) {
+      throw new Error(`API call failed for ${path}: No data in response`);
+    }
+
+    return this.decryptAES(responseJson.data);
+  }
+
+  private async postEncrypted<T>(
+    path: string,
+    session: CachedSession,
+    requestBody: Record<string, unknown> | null,
+    emptyBody: boolean = false
+  ): Promise<T> {
+    const rawResponse = await this.postEncryptedRaw(path, session, requestBody, emptyBody);
+    return JSON.parse(rawResponse) as T;
   }
 
   private async authenticate(): Promise<CachedSession> {
@@ -114,38 +197,11 @@ export class RenphoApiService {
     // Extract user ID as string to preserve precision for large integers
     const userId = this.extractIdAsString(rawLoginData, 'id') || String(login.id);
 
-    // Get device info to find tableName and scale user IDs
-    const deviceResponse = await fetch(`${API_BASE}/renpho-aggregation/device/count`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'token': login.token,
-        'userId': userId,
-        'appVersion': '7.0.0',
-        'platform': 'android'
-      },
-      body: JSON.stringify({ encryptData: this.encryptEmptyBytes() })
-    });
-
-    const deviceJson = await deviceResponse.json() as { code: number; data: string };
-    const rawDeviceData = this.decryptAES(deviceJson.data);
-    const deviceData = JSON.parse(rawDeviceData) as DeviceInfo;
-
-    if (!deviceData.scale || deviceData.scale.length === 0) {
-      throw new Error('No scale devices found');
-    }
-
-    const scaleInfo = deviceData.scale[0];
-
-    // Extract scale user ID as string to preserve precision
-    const scaleUserIds = this.extractUserIdsAsStrings(rawDeviceData);
-    const scaleUserId = scaleUserIds[0] || String(scaleInfo.userIds[0]);
-
-    const session: CachedSession = {
+    const temporarySession: CachedSession = {
       token: login.token,
-      userId: userId,
-      scaleUserId: scaleUserId,
-      tableName: scaleInfo.tableName,
+      userId,
+      scaleUserIds: [],
+      scaleTables: [],
       user: {
         id: userId,
         email: login.email,
@@ -157,9 +213,39 @@ export class RenphoApiService {
         weight_unit: login.weightUnit,
         weight_goal: login.weightGoal,
         locale: login.locale,
-        area_code: login.areaCode
+        area_code: login.areaCode,
+        first_name: login.firstName,
+        last_name: login.lastName,
+        measure_last_time: login.measureLastTime,
+        measure_last_weight: login.measureLastWeight,
+        user_uuid: login.userUuid
       },
-      expires_at: Date.now() + 50 * 60 * 1000 // 50 minutes
+      expires_at: Date.now() + 50 * 60 * 1000
+    };
+
+    const rawDeviceData = await this.postEncryptedRaw(
+      'renpho-aggregation/device/count',
+      temporarySession,
+      null,
+      true
+    );
+    const deviceData = JSON.parse(rawDeviceData) as DeviceInfo;
+    const extractedUserIdGroups = this.extractUserIdGroupsAsStrings(rawDeviceData);
+
+    if (!deviceData.scale || deviceData.scale.length === 0) {
+      throw new Error('No scale devices found');
+    }
+
+    const scaleTables: RenphoScaleTable[] = deviceData.scale.map((scaleInfo, index) => ({
+      table_name: scaleInfo.tableName,
+      count: scaleInfo.count,
+      user_ids: extractedUserIdGroups[index] || (scaleInfo.userIds || []).map(String)
+    }));
+
+    const session: CachedSession = {
+      ...temporarySession,
+      scaleTables,
+      scaleUserIds: this.unique(scaleTables.flatMap(scale => scale.user_ids))
     };
 
     this.sessionCache = session;
@@ -171,94 +257,113 @@ export class RenphoApiService {
     return session.user;
   }
 
-  async getScaleUsers(): Promise<RenphoScaleUser[]> {
+  async getFamilyMembers(): Promise<RenphoUser[]> {
     const session = await this.authenticate();
-    return [{
-      id: session.scaleUserId,
-      user_id: session.scaleUserId,
-      mac: '',
-      index: 0,
-      key: '',
-      method: 0
-    }];
+    const familyMembers = await this.postEncrypted<FamilyMemberResponse[] | { list?: FamilyMemberResponse[] }>(
+      'RenphoHealth/centerUser/queryFamilyMemberList',
+      session,
+      null,
+      true
+    );
+
+    const members = Array.isArray(familyMembers) ? familyMembers : (familyMembers.list || []);
+
+    return members.map(member => ({
+      id: member.id ? String(member.id) : '',
+      email: member.email || '',
+      account_name: member.accountName,
+      birthday: member.birthday,
+      gender: member.gender,
+      height: member.height,
+      height_unit: member.heightUnit,
+      weight_unit: member.weightUnit,
+      weight_goal: member.weightGoal,
+      locale: member.locale,
+      area_code: member.areaCode,
+      first_name: member.firstName,
+      last_name: member.lastName
+    }));
   }
 
-  async getMeasurements(
-    userId?: string,
-    lastAt?: number,
-    limit: number = 100
-  ): Promise<RenphoMeasurement[]> {
+  async getScaleUsers(): Promise<RenphoScaleUser[]> {
     const session = await this.authenticate();
-    const targetUserId = userId || session.scaleUserId;
 
-    const cacheKey = `measurements-${targetUserId}-${lastAt || 'all'}-${limit}`;
-    const cached = this.measurementCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
+    return session.scaleTables.flatMap(scaleTable =>
+      scaleTable.user_ids.map((userId, index) => ({
+        id: `${scaleTable.table_name}:${userId}`,
+        user_id: userId,
+        table_name: scaleTable.table_name,
+        count: scaleTable.count,
+        index,
+        method: 0
+      }))
+    );
+  }
 
-    // API returns oldest first, so fetch more records when filtering by date
-    // to ensure we get recent measurements, then apply limit after filtering
-    const fetchSize = lastAt ? Math.max(limit, 500) : limit;
+  private async fetchMeasurementPage(
+    session: CachedSession,
+    tableName: string,
+    userIds: string[],
+    pageNum: number,
+    pageSize: number
+  ): Promise<Array<Record<string, any>>> {
+    return await this.postEncrypted<Array<Record<string, any>>>(
+      'RenphoHealth/scale/queryAllMeasureDataList',
+      session,
+      {
+        pageNum,
+        pageSize,
+        userIds,
+        tableName
+      }
+    );
+  }
 
-    const measurementRequest = {
-      pageNum: 1,
-      pageSize: fetchSize,
-      userIds: [targetUserId],
-      tableName: session.tableName
-    };
+  private async fetchMeasurementsForTable(
+    session: CachedSession,
+    table: RenphoScaleTable,
+    userIds: string[],
+    limit: number,
+    lastAt?: number
+  ): Promise<Array<Record<string, any>>> {
+    const pageSize = Math.min(DEFAULT_PAGE_SIZE, Math.max(50, limit));
+    const tableCount = Math.max(table.count || 0, 0);
+    const totalPages = Math.max(1, Math.ceil(Math.max(tableCount, pageSize) / pageSize));
+    const collected: Array<Record<string, any>> = [];
 
-    let response: Response;
-    try {
-      response = await fetch(`${API_BASE}/RenphoHealth/scale/queryAllMeasureDataList`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'token': session.token,
-          'userId': session.userId,
-          'appVersion': '7.0.0',
-          'platform': 'android'
-        },
-        body: JSON.stringify({ encryptData: this.encryptAES(JSON.stringify(measurementRequest)) })
-      });
-    } catch (networkError) {
-      throw new Error(`Network error fetching measurements: ${(networkError as Error).message}`);
-    }
-
-    let responseJson: { code: number; msg?: string; data?: string };
-    try {
-      responseJson = await response.json() as { code: number; msg?: string; data?: string };
-    } catch (parseError) {
-      throw new Error(`Failed to parse API response: ${(parseError as Error).message}, status: ${response.status}`);
-    }
-
-    if (responseJson.code !== 101) {
-      throw new Error(`Failed to get measurements: code=${responseJson.code}, msg=${responseJson.msg}, full=${JSON.stringify(responseJson)}`);
-    }
-
-    if (!responseJson.data) {
-      throw new Error('Failed to get measurements: No data in response');
-    }
-
-    const rawMeasurements = JSON.parse(this.decryptAES(responseJson.data)) as Array<Record<string, any>>;
-
-    // Filter by lastAt if provided
-    let filtered = rawMeasurements;
     if (lastAt) {
-      filtered = rawMeasurements.filter(m => m.timeStamp >= lastAt);
+      for (let pageNum = totalPages; pageNum >= 1; pageNum--) {
+        const page = await this.fetchMeasurementPage(session, table.table_name, userIds, pageNum, pageSize);
+        if (page.length === 0) break;
+
+        collected.push(...page);
+
+        const newestTimestampInPage = Math.max(...page.map(entry => Number(entry.timeStamp || 0)));
+        const recentCount = collected.filter(entry => Number(entry.timeStamp || 0) >= lastAt).length;
+        if (recentCount >= limit || newestTimestampInPage < lastAt || collected.length >= MAX_MEASUREMENT_SCAN) {
+          break;
+        }
+      }
+
+      return collected;
     }
 
-    // Sort by timestamp descending (most recent first)
-    filtered.sort((a, b) => b.timeStamp - a.timeStamp);
+    const pagesNeeded = Math.max(1, Math.ceil(limit / pageSize));
+    const startPage = Math.max(1, totalPages - pagesNeeded + 1);
 
-    // Apply limit after filtering and sorting
-    if (filtered.length > limit) {
-      filtered = filtered.slice(0, limit);
+    for (let pageNum = startPage; pageNum <= totalPages; pageNum++) {
+      const page = await this.fetchMeasurementPage(session, table.table_name, userIds, pageNum, pageSize);
+      if (page.length === 0) break;
+      collected.push(...page);
     }
 
-    const measurements: RenphoMeasurement[] = filtered.map(m => ({
+    return collected;
+  }
+
+  private mapMeasurement(m: Record<string, any>): RenphoMeasurement {
+    return {
       id: String(m.id),
-      time_stamp: m.timeStamp,
+      time_stamp: Number(m.timeStamp),
       weight: m.weight,
       bmi: m.bmi,
       bodyfat: m.bodyfat,
@@ -276,23 +381,122 @@ export class RenphoApiService {
       resistance: m.resistance,
       fat_free_weight: m.fatFreeWeight,
       metabolic_age: m.bodyage,
-      user_id: String(m.bUserId),
-      scale_user_id: String(m.subUserId),
+      user_id: m.bUserId != null ? String(m.bUserId) : undefined,
+      scale_user_id: m.subUserId != null ? String(m.subUserId) : undefined,
       mac: m.mac,
       internal_model: m.internalModel,
       scale_name: m.scaleName,
       method: m.method,
       pregnant_flag: undefined,
-      sport_flag: m.sportFlag
-    }));
+      sport_flag: m.sportFlag,
+      is_auto: m.isAuto,
+      is_new: m.isNew,
+      invalid_flag: m.invalidFlag
+    };
+  }
+
+  private dedupeAndSortMeasurements(measurements: RenphoMeasurement[]): RenphoMeasurement[] {
+    const uniqueById = new Map<string, RenphoMeasurement>();
+    for (const measurement of measurements) {
+      if (!uniqueById.has(measurement.id)) {
+        uniqueById.set(measurement.id, measurement);
+      }
+    }
+
+    return Array.from(uniqueById.values()).sort((a, b) => b.time_stamp - a.time_stamp);
+  }
+
+  private selectMeasurementsForCurrentUser(
+    measurements: RenphoMeasurement[],
+    session: CachedSession
+  ): RenphoMeasurement[] {
+    const directlyBound = measurements.filter(measurement => measurement.user_id === session.userId);
+    if (directlyBound.length > 0) {
+      return directlyBound;
+    }
+
+    if (session.scaleUserIds.length === 1) {
+      return measurements.filter(measurement => measurement.scale_user_id === session.scaleUserIds[0]);
+    }
+
+    return measurements.filter(measurement => measurement.scale_user_id === session.scaleUserIds[0]);
+  }
+
+  private async getAssociatedMeasurements(lastAt?: number, limit: number = 100): Promise<RenphoMeasurement[]> {
+    const session = await this.authenticate();
+    const cacheKey = `associated-measurements-${lastAt || 'all'}-${limit}`;
+    const cached = this.measurementCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const perTableLimit = Math.max(limit, 50);
+    const rawResults = await Promise.all(
+      session.scaleTables.map(scaleTable =>
+        this.fetchMeasurementsForTable(session, scaleTable, scaleTable.user_ids, perTableLimit, lastAt)
+      )
+    );
+
+    let measurements = this.dedupeAndSortMeasurements(rawResults.flat().map(entry => this.mapMeasurement(entry)));
+
+    if (lastAt) {
+      measurements = measurements.filter(measurement => measurement.time_stamp >= lastAt);
+    }
+
+    if (measurements.length > limit) {
+      measurements = measurements.slice(0, limit);
+    }
+
+    this.measurementCache.set(cacheKey, measurements);
+    return measurements;
+  }
+
+  async getMeasurements(
+    userId?: string,
+    lastAt?: number,
+    limit: number = 100
+  ): Promise<RenphoMeasurement[]> {
+    const session = await this.authenticate();
+
+    if (!userId) {
+      const associatedMeasurements = await this.getAssociatedMeasurements(lastAt, Math.max(limit, 200));
+      const selected = this.selectMeasurementsForCurrentUser(associatedMeasurements, session);
+      return selected.slice(0, limit);
+    }
+
+    const cacheKey = `measurements-${userId}-${lastAt || 'all'}-${limit}`;
+    const cached = this.measurementCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const candidateTables = session.scaleTables.filter(scaleTable => scaleTable.user_ids.includes(userId));
+    const tablesToQuery = candidateTables.length > 0
+      ? candidateTables
+      : session.scaleTables;
+
+    const rawResults = await Promise.all(
+      tablesToQuery.map(scaleTable =>
+        this.fetchMeasurementsForTable(session, scaleTable, [userId], Math.max(limit, 50), lastAt)
+      )
+    );
+
+    let measurements = this.dedupeAndSortMeasurements(rawResults.flat().map(entry => this.mapMeasurement(entry)));
+
+    if (lastAt) {
+      measurements = measurements.filter(measurement => measurement.time_stamp >= lastAt);
+    }
+
+    if (measurements.length > limit) {
+      measurements = measurements.slice(0, limit);
+    }
 
     this.measurementCache.set(cacheKey, measurements);
     return measurements;
   }
 
   async getLatestMeasurement(): Promise<RenphoMeasurement | null> {
-    // API returns oldest first, so we need to fetch all to get the most recent
-    const measurements = await this.getMeasurements(undefined, undefined, 1000);
+    const measurements = await this.getMeasurements(undefined, undefined, 1);
     return measurements.length > 0 ? measurements[0] : null;
   }
 
@@ -334,7 +538,6 @@ export class RenphoApiService {
 
     if (measurements.length === 0) return null;
 
-    // Sort by timestamp ascending for trend calculation
     const sorted = [...measurements].sort((a, b) => a.time_stamp - b.time_stamp);
     const weights = sorted.map(m => m.weight).filter((w): w is number => w != null);
 
@@ -358,6 +561,36 @@ export class RenphoApiService {
       max_weight: maxWeight,
       avg_weight: avgWeight,
       measurement_count: measurements.length
+    };
+  }
+
+  async getSyncDiagnostics(days: number = 7): Promise<RenphoSyncDiagnostics> {
+    const session = await this.authenticate();
+    const startTimestamp = Math.floor((Date.now() - days * 24 * 60 * 60 * 1000) / 1000);
+    const [familyMembers, associatedMeasurements] = await Promise.all([
+      this.getFamilyMembers().catch(() => []),
+      this.getAssociatedMeasurements(startTimestamp, 50)
+    ]);
+
+    const visibleMeasurements = this.selectMeasurementsForCurrentUser(associatedMeasurements, session);
+    const visibleLatestMeasurement = visibleMeasurements[0] || null;
+    const latestAssociatedMeasurement = associatedMeasurements[0] || null;
+    const hiddenAssociatedMeasurements = associatedMeasurements
+      .filter(measurement => !visibleMeasurements.some(visible => visible.id === measurement.id))
+      .slice(0, 5);
+
+    const latestMeasurementAgeHours = visibleLatestMeasurement
+      ? (Date.now() / 1000 - visibleLatestMeasurement.time_stamp) / 3600
+      : undefined;
+
+    return {
+      user: session.user,
+      family_members: familyMembers,
+      scale_tables: session.scaleTables,
+      visible_latest_measurement: visibleLatestMeasurement,
+      latest_associated_measurement: latestAssociatedMeasurement,
+      hidden_associated_measurements: hiddenAssociatedMeasurements,
+      latest_measurement_age_hours: latestMeasurementAgeHours
     };
   }
 

--- a/src/services/renpho-api.ts
+++ b/src/services/renpho-api.ts
@@ -89,6 +89,11 @@ export class RenphoApiService {
     return match ? match[1] : null;
   }
 
+  private extractIdsAsStrings(json: string, key: string): string[] {
+    const regex = new RegExp(`"${key}":(\\d+)`, 'g');
+    return Array.from(json.matchAll(regex), match => match[1]);
+  }
+
   // Extract all userIds arrays as string arrays to avoid precision loss
   private extractUserIdGroupsAsStrings(json: string): string[][] {
     const matches = json.matchAll(/"userIds":\[(\d+(?:,\d+)*)\]/g);
@@ -307,7 +312,7 @@ export class RenphoApiService {
     pageNum: number,
     pageSize: number
   ): Promise<Array<Record<string, any>>> {
-    return await this.postEncrypted<Array<Record<string, any>>>(
+    const rawResponse = await this.postEncryptedRaw(
       'RenphoHealth/scale/queryAllMeasureDataList',
       session,
       {
@@ -317,6 +322,18 @@ export class RenphoApiService {
         tableName
       }
     );
+
+    const parsed = JSON.parse(rawResponse) as Array<Record<string, any>>;
+    const ids = this.extractIdsAsStrings(rawResponse, 'id');
+    const boundUserIds = this.extractIdsAsStrings(rawResponse, 'bUserId');
+    const scaleUserIds = this.extractIdsAsStrings(rawResponse, 'subUserId');
+
+    return parsed.map((entry, index) => ({
+      ...entry,
+      __idString: ids[index] || (entry.id != null ? String(entry.id) : undefined),
+      __bUserIdString: boundUserIds[index] || (entry.bUserId != null ? String(entry.bUserId) : undefined),
+      __subUserIdString: scaleUserIds[index] || (entry.subUserId != null ? String(entry.subUserId) : undefined)
+    }));
   }
 
   private async fetchMeasurementsForTable(
@@ -362,7 +379,7 @@ export class RenphoApiService {
 
   private mapMeasurement(m: Record<string, any>): RenphoMeasurement {
     return {
-      id: String(m.id),
+      id: m.__idString || String(m.id),
       time_stamp: Number(m.timeStamp),
       weight: m.weight,
       bmi: m.bmi,
@@ -381,8 +398,8 @@ export class RenphoApiService {
       resistance: m.resistance,
       fat_free_weight: m.fatFreeWeight,
       metabolic_age: m.bodyage,
-      user_id: m.bUserId != null ? String(m.bUserId) : undefined,
-      scale_user_id: m.subUserId != null ? String(m.subUserId) : undefined,
+      user_id: m.__bUserIdString || (m.bUserId != null ? String(m.bUserId) : undefined),
+      scale_user_id: m.__subUserIdString || (m.subUserId != null ? String(m.subUserId) : undefined),
       mac: m.mac,
       internal_model: m.internalModel,
       scale_name: m.scaleName,

--- a/src/types/renpho.ts
+++ b/src/types/renpho.ts
@@ -2,6 +2,8 @@ export interface RenphoUser {
   id: string;
   email: string;
   account_name?: string;
+  first_name?: string;
+  last_name?: string;
   birthday?: string;
   gender?: number;
   height?: number;
@@ -10,6 +12,9 @@ export interface RenphoUser {
   weight_goal?: number;
   locale?: string;
   area_code?: string;
+  measure_last_time?: string;
+  measure_last_weight?: string;
+  user_uuid?: string;
 }
 
 export interface RenphoMeasurement {
@@ -40,11 +45,16 @@ export interface RenphoMeasurement {
   method?: number;
   pregnant_flag?: number;
   sport_flag?: number;
+  is_auto?: number;
+  is_new?: boolean;
+  invalid_flag?: number;
 }
 
 export interface RenphoScaleUser {
   id: string;
   user_id: string;
+  table_name?: string;
+  count?: number;
   mac?: string;
   index?: number;
   key?: string;
@@ -56,6 +66,12 @@ export interface RenphoScaleUser {
   weight_goal?: number;
   created_at?: string;
   updated_at?: string;
+}
+
+export interface RenphoScaleTable {
+  table_name: string;
+  user_ids: string[];
+  count: number;
 }
 
 export interface RenphoSession {
@@ -98,4 +114,14 @@ export interface RenphoBodyComposition {
     bodyfat_category: string;
     visceral_fat_category: string;
   };
+}
+
+export interface RenphoSyncDiagnostics {
+  user: RenphoUser;
+  family_members: RenphoUser[];
+  scale_tables: RenphoScaleTable[];
+  visible_latest_measurement: RenphoMeasurement | null;
+  latest_associated_measurement: RenphoMeasurement | null;
+  hidden_associated_measurements: RenphoMeasurement[];
+  latest_measurement_age_hours?: number;
 }

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,4 +1,11 @@
-import { RenphoMeasurement, RenphoBodyComposition, RenphoWeightTrend, RenphoUser } from '../types/renpho.js';
+import {
+  RenphoMeasurement,
+  RenphoBodyComposition,
+  RenphoWeightTrend,
+  RenphoUser,
+  RenphoScaleUser,
+  RenphoSyncDiagnostics
+} from '../types/renpho.js';
 
 export function formatDate(timestamp: number): string {
   return new Date(timestamp * 1000).toLocaleDateString('en-US', {
@@ -11,10 +18,12 @@ export function formatDate(timestamp: number): string {
 }
 
 export function formatUser(user: RenphoUser): string {
-  let text = `User: ${user.account_name || user.email}\n`;
+  let text = `User: ${user.account_name || [user.first_name, user.last_name].filter(Boolean).join(' ') || user.email}\n`;
   text += `Email: ${user.email}\n`;
   if (user.height) text += `Height: ${user.height} cm\n`;
   if (user.weight_goal) text += `Weight Goal: ${user.weight_goal} kg\n`;
+  if (user.measure_last_time) text += `App Last Measurement Time: ${user.measure_last_time}\n`;
+  if (user.measure_last_weight) text += `App Last Measurement Weight: ${user.measure_last_weight}\n`;
   return text;
 }
 
@@ -48,6 +57,13 @@ export function formatMeasurement(m: RenphoMeasurement): string {
     text += `- Heart Rate: ${m.heart_rate} bpm\n`;
     if (m.cardiac_index) text += `- Cardiac Index: ${m.cardiac_index}\n`;
   }
+
+  text += `\n**Source:**\n`;
+  if (m.user_id) text += `- Bound User ID: ${m.user_id}\n`;
+  if (m.scale_user_id) text += `- Scale User ID: ${m.scale_user_id}\n`;
+  if (m.method != null) text += `- Method: ${m.method}\n`;
+  if (m.is_auto != null) text += `- Auto Source Flag: ${m.is_auto}\n`;
+  if (m.is_new != null) text += `- New Flag: ${m.is_new ? 'true' : 'false'}\n`;
 
   return text;
 }
@@ -95,16 +111,75 @@ export function formatMeasurementList(measurements: RenphoMeasurement[]): string
   }
 
   let text = `**Recent Measurements (${measurements.length})**\n\n`;
-  text += `| Date | Weight | Body Fat | Muscle | BMI |\n`;
-  text += `|------|--------|----------|--------|-----|\n`;
+  text += `| Date | Weight | Body Fat | Muscle | BMI | Bound User | Scale User |\n`;
+  text += `|------|--------|----------|--------|-----|------------|------------|\n`;
 
   for (const m of measurements.slice(0, 20)) {
     const date = formatDate(m.time_stamp).split(',')[0];
-    text += `| ${date} | ${m.weight?.toFixed(1) || '-'} kg | ${m.bodyfat?.toFixed(1) || '-'}% | ${m.muscle?.toFixed(1) || '-'}% | ${m.bmi?.toFixed(1) || '-'} |\n`;
+    text += `| ${date} | ${m.weight?.toFixed(1) || '-'} kg | ${m.bodyfat?.toFixed(1) || '-'}% | ${m.muscle?.toFixed(1) || '-'}% | ${m.bmi?.toFixed(1) || '-'} | ${m.user_id || '-'} | ${m.scale_user_id || '-'} |\n`;
   }
 
   if (measurements.length > 20) {
     text += `\n...and ${measurements.length - 20} more measurements`;
+  }
+
+  return text;
+}
+
+export function formatScaleUsers(scaleUsers: RenphoScaleUser[]): string {
+  if (scaleUsers.length === 0) {
+    return 'No scale users found.';
+  }
+
+  let text = `**Scale Users (${scaleUsers.length})**\n\n`;
+  text += `| Scale User ID | Table | Count |\n`;
+  text += `|---------------|-------|-------|\n`;
+
+  for (const scaleUser of scaleUsers) {
+    text += `| ${scaleUser.user_id} | ${scaleUser.table_name || '-'} | ${scaleUser.count ?? '-'} |\n`;
+  }
+
+  return text;
+}
+
+export function formatSyncDiagnostics(diagnostics: RenphoSyncDiagnostics): string {
+  let text = `**Sync Diagnostics**\n\n`;
+  text += `Current user: ${diagnostics.user.account_name || diagnostics.user.email} (${diagnostics.user.id})\n`;
+  text += `Scale tables: ${diagnostics.scale_tables.length}\n`;
+  text += `Family members: ${diagnostics.family_members.length}\n`;
+
+  if (diagnostics.latest_measurement_age_hours != null) {
+    text += `Visible latest age: ${diagnostics.latest_measurement_age_hours.toFixed(1)} hours\n`;
+  }
+
+  text += `\n**Scale Tables**\n`;
+  for (const table of diagnostics.scale_tables) {
+    text += `- ${table.table_name}: ${table.count} records, userIds=[${table.user_ids.join(', ')}]\n`;
+  }
+
+  if (diagnostics.family_members.length > 0) {
+    text += `\n**Family Members**\n`;
+    for (const member of diagnostics.family_members) {
+      const name = member.account_name || [member.first_name, member.last_name].filter(Boolean).join(' ') || member.email || member.id;
+      text += `- ${name} (${member.id || 'unknown-id'})\n`;
+    }
+  }
+
+  text += `\n**Visible Latest Measurement**\n`;
+  text += diagnostics.visible_latest_measurement
+    ? `${formatMeasurement(diagnostics.visible_latest_measurement)}\n`
+    : 'No visible measurement found.\n';
+
+  text += `\n**Latest Associated Measurement Across All Linked Scale Users**\n`;
+  text += diagnostics.latest_associated_measurement
+    ? `${formatMeasurement(diagnostics.latest_associated_measurement)}\n`
+    : 'No associated measurements found.\n';
+
+  if (diagnostics.hidden_associated_measurements.length > 0) {
+    text += `\n**Associated Measurements Not Currently Selected For Current User**\n`;
+    for (const measurement of diagnostics.hidden_associated_measurements) {
+      text += `- ${formatDate(measurement.time_stamp)} | ${measurement.weight?.toFixed(1) || 'N/A'} kg | bound=${measurement.user_id || '-'} | scale=${measurement.scale_user_id || '-'}\n`;
+    }
   }
 
   return text;

--- a/test/renpho-api.test.ts
+++ b/test/renpho-api.test.ts
@@ -92,7 +92,19 @@ test('getMeasurements falls back to the only scale user when measurements are no
   assert.equal(measurements[0].id, 'pending-bind');
 });
 
-test('fetchMeasurementsForTable pulls newest pages first when filtering by recent timestamps', async () => {
+test('fetchMeasurementPage preserves big integer ids as strings', async () => {
+  const service = createService() as any;
+  service.postEncryptedRaw = async () => '[{"id":5919278420902642176,"timeStamp":1771059525,"bUserId":5245536005636456320,"subUserId":5245536005636456320,"weight":88.15}]';
+
+  const page = await service.fetchMeasurementPage(createSession(), 'table_a', ['scale-1'], 1, 50);
+  const mapped = service.mapMeasurement(page[0]);
+
+  assert.equal(mapped.id, '5919278420902642176');
+  assert.equal(mapped.user_id, '5245536005636456320');
+  assert.equal(mapped.scale_user_id, '5245536005636456320');
+});
+
+test('fetchMeasurementsForTable pulls newest pages first when filtering recent timestamps', async () => {
   const service = createService() as any;
   const pagesVisited: number[] = [];
   service.fetchMeasurementPage = async (

--- a/test/renpho-api.test.ts
+++ b/test/renpho-api.test.ts
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RenphoApiService } from '../src/services/renpho-api.js';
+import type { RenphoMeasurement } from '../src/types/renpho.js';
+
+function createService() {
+  return new RenphoApiService('test@example.com', 'password');
+}
+
+function createSession() {
+  return {
+    token: 'token',
+    userId: 'user-1',
+    scaleUserIds: ['scale-1', 'scale-2'],
+    scaleTables: [
+      { table_name: 'table_a', user_ids: ['scale-1'], count: 120 },
+      { table_name: 'table_b', user_ids: ['scale-2'], count: 120 }
+    ],
+    user: {
+      id: 'user-1',
+      email: 'test@example.com'
+    },
+    expires_at: Date.now() + 60_000
+  };
+}
+
+function measurement(overrides: Partial<RenphoMeasurement>): RenphoMeasurement {
+  return {
+    id: 'm-1',
+    time_stamp: 1,
+    weight: 80,
+    ...overrides
+  };
+}
+
+test('getScaleUsers returns every discovered scale user across tables', async () => {
+  const service = createService() as any;
+  service.authenticate = async () => createSession();
+
+  const scaleUsers = await service.getScaleUsers();
+
+  assert.equal(scaleUsers.length, 2);
+  assert.deepEqual(
+    scaleUsers.map((entry: any) => ({ user_id: entry.user_id, table_name: entry.table_name })),
+    [
+      { user_id: 'scale-1', table_name: 'table_a' },
+      { user_id: 'scale-2', table_name: 'table_b' }
+    ]
+  );
+});
+
+test('getMeasurements prefers measurements already bound to the logged in user', async () => {
+  const service = createService() as any;
+  const session = createSession();
+  service.authenticate = async () => session;
+  service.getAssociatedMeasurements = async () => [
+    measurement({
+      id: 'hidden-newer',
+      time_stamp: 200,
+      scale_user_id: 'scale-2',
+      user_id: 'other-user'
+    }),
+    measurement({
+      id: 'visible-current-user',
+      time_stamp: 150,
+      scale_user_id: 'scale-1',
+      user_id: 'user-1'
+    })
+  ];
+
+  const measurements = await service.getMeasurements(undefined, undefined, 10);
+
+  assert.equal(measurements.length, 1);
+  assert.equal(measurements[0].id, 'visible-current-user');
+});
+
+test('getMeasurements falls back to the only scale user when measurements are not yet bound', async () => {
+  const service = createService() as any;
+  const session = {
+    ...createSession(),
+    scaleUserIds: ['scale-1'],
+    scaleTables: [{ table_name: 'table_a', user_ids: ['scale-1'], count: 2 }]
+  };
+  service.authenticate = async () => session;
+  service.getAssociatedMeasurements = async () => [
+    measurement({ id: 'pending-bind', time_stamp: 300, scale_user_id: 'scale-1' })
+  ];
+
+  const measurements = await service.getMeasurements(undefined, undefined, 10);
+
+  assert.equal(measurements.length, 1);
+  assert.equal(measurements[0].id, 'pending-bind');
+});
+
+test('fetchMeasurementsForTable pulls newest pages first when filtering by recent timestamps', async () => {
+  const service = createService() as any;
+  const pagesVisited: number[] = [];
+  service.fetchMeasurementPage = async (
+    _session: unknown,
+    _tableName: string,
+    _userIds: string[],
+    pageNum: number
+  ) => {
+    pagesVisited.push(pageNum);
+
+    if (pageNum === 3) {
+      return [
+        { id: 3, timeStamp: 300, weight: 80 },
+        { id: 4, timeStamp: 250, weight: 79 }
+      ];
+    }
+
+    if (pageNum === 2) {
+      return [
+        { id: 2, timeStamp: 150, weight: 78 },
+        { id: 5, timeStamp: 120, weight: 77 }
+      ];
+    }
+
+    return [
+      { id: 1, timeStamp: 90, weight: 76 }
+    ];
+  };
+
+  const results = await service.fetchMeasurementsForTable(
+    createSession(),
+    { table_name: 'table_a', user_ids: ['scale-1'], count: 120 },
+    ['scale-1'],
+    2,
+    200
+  );
+
+  assert.deepEqual(pagesVisited, [3]);
+  assert.deepEqual(results.map((entry: any) => entry.id), [3, 4]);
+});


### PR DESCRIPTION
## Summary

Fixes StartupBros/renpho-mcp-server#1 by making measurement discovery a lot more reliable for Wi-Fi scale data.

The server was making two bad assumptions:

1. it treated the first discovered Renpho scale user and table as the only source of truth
2. it let large Renpho measurement IDs lose precision in JavaScript, which could break binding checks against the logged-in user

This change fixes both, adds diagnostics so delayed sync cases are easier to understand, and confirms the behavior against a real Renpho account.

## What changed

- scan all linked Renpho scale tables instead of only the first one
- fetch newer measurement pages first when looking for recent data
- preserve large Renpho measurement IDs and user IDs as strings so binding logic stays accurate
- expose extra source metadata on measurements, including bound user ID and scale user ID
- add `get_scale_users` to inspect linked scale-user mappings
- add `get_sync_diagnostics` to surface hidden or delayed measurements across linked scale users
- add `refresh_data` to clear caches and force a fresh Renpho session
- document the Wi-Fi sync caveat and the new debugging tools in `README.md`

## Why this matters

The reporter's issue looked like a possible hidden app-side sync call, and that may still exist in some cases. But before we can reason about that confidently, the server needs to stop missing data that is already present.

With this branch in place, the server now:

- checks every linked scale table
- keeps Renpho bigint identifiers intact
- selects the right measurement set for the current user much more reliably
- gives us enough diagnostics to tell whether a new weigh-in is truly missing or just sitting in a different linked path

## Testing

### Automated

- `pnpm build`
- `pnpm test`

Added regression coverage for:

- discovering all linked scale users across tables
- preferring measurements already bound to the logged-in user
- falling back correctly when a measurement is not bound yet
- scanning newest pages first for recent measurements
- preserving bigint measurement IDs as strings

### Live verification

Verified against a real Renpho account:

- `getCurrentUser()`
- `getScaleUsers()`
- `getLatestMeasurement()`
- `getSyncDiagnostics(90)`

The live check confirmed two linked scale users and a valid latest measurement returned through the updated code path.
