### PR TITLE
chore: worktree hygiene + gitignore .token-eater (rescued from diverged local main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # Test coverage
 coverage/
+
+# Claude Code parallel worktrees
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ coverage/
 
 # Claude Code parallel worktrees
 .claude/worktrees/
+.token-eater/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+# Gitignored files auto-copied into fresh worktrees so agents do not fail on missing config.
+# gitignore syntax. Add any other runtime config a worktree agent needs.
+.env
+.env.*
+.env.local


### PR DESCRIPTION
Local main had drifted 1-ahead/10-behind origin; the stranded 06-22 hygiene commit + a .gitignore line are rescued here and local main realigned to origin.